### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the missing GitHub Skills activity to the activities list.

Resolves #6

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Activity includes:
  - Description emphasizing GitHub Certifications and college application benefits
  - Schedule: Wednesdays, 3:30 PM - 4:30 PM
  - Capacity: 25 participants
  - No initial participants (ready for signups)

## Testing
The activity should now:
- Appear in the GET `/activities` endpoint response
- Be selectable in the activity dropdown on the frontend
- Accept registrations from students